### PR TITLE
Upgrade to net10.0 and OpenCvSharp5

### DIFF
--- a/BlazorApp/BlazorApp.csproj
+++ b/BlazorApp/BlazorApp.csproj
@@ -1,11 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <WasmBuildNative>true</WasmBuildNative>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Without trimming, the linker sees every P/Invoke declared in OpenCvSharp.dll (including
+         modules the wasm native lib doesn't build, e.g. text/dnn), not just the ones this app
+         calls. Allow those to stay unresolved; they only fail if actually invoked at runtime. -->
+    <WasmAllowUndefinedSymbols>true</WasmAllowUndefinedSymbols>
+    <WasmInitialHeapSize>134217728</WasmInitialHeapSize>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -17,10 +22,28 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.1" PrivateAssets="all" />
-    <PackageReference Include="OpenCvSharp4" Version="4.5.5.20211231" />
-    <PackageReference Include="OpenCvSharp4.runtime.wasm" Version="4.5.5.20211231" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.9" PrivateAssets="all" />
+    <PackageReference Include="OpenCvSharp5" Version="5.0.0.20260703" />
+    <PackageReference Include="OpenCvSharp5.runtime.wasm" Version="5.0.0.20260703" />
   </ItemGroup>
+
+  <!--
+    Workaround: OpenCvSharp5.runtime.wasm ships "libOpenCvSharpExtern.a", but the managed side
+    declares [LibraryImport("OpenCvSharpExtern")] (no "lib" prefix). The wasm toolchain derives the
+    P/Invoke module name from the native file's name verbatim (MSBuild %(Filename)), so this
+    mismatch leaves the generated P/Invoke table empty and every native call throws
+    DllNotFoundException at runtime. Re-reference a locally renamed copy so the names line up.
+  -->
+  <Target Name="FixOpenCvSharpWasmNativeLibName" BeforeTargets="_PrepareForBrowserWasmBuildNative">
+    <ItemGroup>
+      <_OpenCvSharpWasmNativeSrc Include="@(NativeFileReference)" Condition="'%(Filename)' == 'libOpenCvSharpExtern'" />
+      <NativeFileReference Remove="@(_OpenCvSharpWasmNativeSrc)" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_OpenCvSharpWasmNativeSrc)" DestinationFiles="$(IntermediateOutputPath)OpenCvSharpExtern.a" SkipUnchangedFiles="true" Condition="'@(_OpenCvSharpWasmNativeSrc)' != ''" />
+    <ItemGroup>
+      <NativeFileReference Include="$(IntermediateOutputPath)OpenCvSharpExtern.a" Condition="'@(_OpenCvSharpWasmNativeSrc)' != ''" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/BlazorApp/CanvasClient.cs
+++ b/BlazorApp/CanvasClient.cs
@@ -29,10 +29,11 @@ namespace BlazorApp
             try
             {
                 var type = mat.Type();
+                rgba = new Mat();
                 if (type == MatType.CV_8UC1)
-                    rgba = mat.CvtColor(ColorConversionCodes.GRAY2RGBA);
+                    Cv2.CvtColor(mat, rgba, ColorConversionCodes.GRAY2RGBA);
                 else if (type == MatType.CV_8UC3)
-                    rgba = mat.CvtColor(ColorConversionCodes.BGR2RGBA);
+                    Cv2.CvtColor(mat, rgba, ColorConversionCodes.BGR2RGBA);
                 else
                     throw new ArgumentException($"Invalid mat type ({mat.Type()})");
 

--- a/BlazorApp/Pages/OpenCvSharpSample.razor
+++ b/BlazorApp/Pages/OpenCvSharpSample.razor
@@ -1,5 +1,6 @@
 ﻿@page "/opencvsharp_sample"
 @using OpenCvSharp
+@using OpenCvSharp.XFeatures2D
 @inject IJSRuntime jsRuntime;
 @inject HttpClient httpClient;
 @implements IDisposable
@@ -126,7 +127,7 @@
 
         using var akaze = AKAZE.Create();
         using var descriptors = new Mat();
-        akaze.DetectAndCompute(grayMat, null, out var keypoints, descriptors);
+        akaze.DetectAndCompute(grayMat, default, out var keypoints, descriptors);
 
         using var dstMat = srcMat.Clone();
         Cv2.DrawKeypoints(srcMat, keypoints, dstMat);


### PR DESCRIPTION
## Summary
- Bump `BlazorApp` from `net6.0` + `OpenCvSharp4` 4.5.5 to `net10.0` + `OpenCvSharp5` 5.0.0.20260703, and Blazor WASM packages to 10.0.9.
- Fix API breakage from the OpenCvSharp4→5 migration: `Mat.CvtColor` instance extension no longer exists (use `Cv2.CvtColor(src, dst, code)`), `AKAZE` moved to `OpenCvSharp.XFeatures2D`, and `InputArray` is now a non-nullable ref struct so the AKAZE mask argument needs `default` instead of `null`.
- Work around an `OpenCvSharp5.runtime.wasm` packaging bug: the package ships `libOpenCvSharpExtern.a`, but the managed side declares `[LibraryImport("OpenCvSharpExtern")]` (no `lib` prefix). The wasm toolchain matches P/Invoke modules to native files by literal filename, so this mismatch silently produces an empty P/Invoke table — the build succeeds, but every native call throws `DllNotFoundException` at runtime. Added an MSBuild target that re-references a locally renamed copy of the `.a` file before the wasm link step.
- Set `WasmAllowUndefinedSymbols=true` and a larger `WasmInitialHeapSize`, needed because a non-trimmed (Debug) build tries to resolve every P/Invoke OpenCvSharp.dll declares, including ones from OpenCV modules the wasm native build doesn't include (e.g. `text_Ptr_TextDetectorCNN_get`).

## Test plan
- [x] `dotnet build` succeeds
- [x] `dotnet run` dev server verified live in browser: Index page renders `Cv2.GetBuildInformation()`, OpenCvSharp sample's Grayscale/PseudoColor/Threshold/Canny/AKAZE buttons all render correct output on the canvas, Canvas Sample page has no console errors
- [ ] `dotnet publish -c Release` still fails (AOT compiler crash on `OpenCvSharp.dll`, and separately a `wasm-opt`/SDK option mismatch when AOT is disabled) — tracked as follow-up, not fixed in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the application to the latest .NET and OpenCV-based WebAssembly platform versions.
  * Added support for AKAZE feature detection in the OpenCV sample.

* **Bug Fixes**
  * Improved image rendering for grayscale and color images on the canvas.
  * Resolved WebAssembly compatibility issues that could prevent OpenCV functionality from loading or running correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->