### PR TITLE
Add GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, deploy/github-pages ]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,71 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+env:
+  # dotnet/runtime#114723: the wasm-opt bundled with the current wasm-tools workload predates
+  # binaryen PR #7106 (bulk-memory-opt / call-indirect-overlong), so Release publish fails.
+  # Swap in a newer binaryen build before publishing. Bump these together when updating.
+  BINARYEN_VERSION: version_130
+  BINARYEN_SHA256: 0a18362361ad05465118cd8eeb72edaeec89de6894bc283576ef4e07aa3babcc
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.3xx'
+
+      - name: Install wasm-tools workload
+        run: dotnet workload install wasm-tools
+
+      - name: Work around outdated bundled wasm-opt (dotnet/runtime#114723)
+        run: |
+          set -euo pipefail
+          WASM_OPT_PATH=$(find /usr/share/dotnet/packs -type f -name 'wasm-opt' | head -1)
+          echo "Patching: $WASM_OPT_PATH"
+          curl -sSL -o binaryen.tar.gz "https://github.com/WebAssembly/binaryen/releases/download/${BINARYEN_VERSION}/binaryen-${BINARYEN_VERSION}-x86_64-linux.tar.gz"
+          echo "${BINARYEN_SHA256}  binaryen.tar.gz" | sha256sum -c -
+          tar xzf binaryen.tar.gz
+          cp "binaryen-${BINARYEN_VERSION}/bin/wasm-opt" "$WASM_OPT_PATH"
+          "$WASM_OPT_PATH" --version
+
+      - name: Publish
+        run: dotnet publish BlazorApp/BlazorApp.csproj -c Release -o publish-output
+
+      - name: Rewrite base href for the GitHub Pages project subpath
+        run: sed -i "s|<base href=\"/\" />|<base href=\"/${{ github.event.repository.name }}/\" />|" publish-output/wwwroot/index.html
+
+      - name: Add GitHub Pages SPA fallback
+        run: |
+          touch publish-output/wwwroot/.nojekyll
+          cp publish-output/wwwroot/index.html publish-output/wwwroot/404.html
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: publish-output/wwwroot
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -7,8 +7,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -63,6 +61,9 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [ main, deploy/github-pages ]
+    branches: [ main ]
   workflow_dispatch:
 
 permissions:

--- a/BlazorApp/BlazorApp.csproj
+++ b/BlazorApp/BlazorApp.csproj
@@ -18,7 +18,10 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <RunAOTCompilation>True</RunAOTCompilation>
+    <!-- AOT-compiling OpenCvSharp.dll currently crashes mono-aot-cross with a native GC assertion
+         (sgen-alloc.c:409) on the current wasm-tools workload, on both net8.0 and net10.0. Leave
+         AOT off for Release until that's fixed upstream; pass -p:RunAOTCompilation=true to retry. -->
+    <RunAOTCompilation>False</RunAOTCompilation>
   </PropertyGroup>
 
   <ItemGroup>
@@ -45,5 +48,25 @@
       <NativeFileReference Include="$(IntermediateOutputPath)OpenCvSharpExtern.a" Condition="'@(_OpenCvSharpWasmNativeSrc)' != ''" />
     </ItemGroup>
   </Target>
+
+  <!--
+    The wasm-opt bundled with the current wasm-tools workload (v117) predates binaryen PR #7106
+    (bulk-memory-opt / call-indirect-overlong, added in v121) - see dotnet/runtime#114723. emcc's
+    own internal link-time wasm-opt pass enables the full modern feature set and produces opcodes
+    (e.g. nontrapping-float-to-int from libwebp) that this second, SDK-driven wasm-opt pass then
+    rejects because its flag set doesn't match. This only matters once wasm-opt itself is new
+    enough to accept "--enable-bulk-memory-opt" (see the CI publish workflow, which swaps in a
+    newer build) - harmless otherwise since Debug builds don't invoke this optimization pass.
+  -->
+  <ItemGroup Condition="'$(WasmBuildNative)' == 'true'">
+    <WasmOptConfigurationFlags Include="--enable-nontrapping-float-to-int" />
+    <WasmOptConfigurationFlags Include="--enable-bulk-memory-opt" />
+    <WasmOptConfigurationFlags Include="--enable-call-indirect-overlong" />
+    <WasmOptConfigurationFlags Include="--enable-multivalue" />
+    <WasmOptConfigurationFlags Include="--enable-mutable-globals" />
+    <WasmOptConfigurationFlags Include="--enable-reference-types" />
+    <WasmOptConfigurationFlags Include="--enable-sign-ext" />
+    <WasmOptConfigurationFlags Include="--enable-threads" />
+  </ItemGroup>
 
 </Project>

--- a/BlazorApp/BlazorApp.csproj
+++ b/BlazorApp/BlazorApp.csproj
@@ -50,13 +50,13 @@
   </Target>
 
   <!--
-    The wasm-opt bundled with the current wasm-tools workload (v117) predates binaryen PR #7106
-    (bulk-memory-opt / call-indirect-overlong, added in v121) - see dotnet/runtime#114723. emcc's
-    own internal link-time wasm-opt pass enables the full modern feature set and produces opcodes
-    (e.g. nontrapping-float-to-int from libwebp) that this second, SDK-driven wasm-opt pass then
-    rejects because its flag set doesn't match. This only matters once wasm-opt itself is new
-    enough to accept "--enable-bulk-memory-opt" (see the CI publish workflow, which swaps in a
-    newer build) - harmless otherwise since Debug builds don't invoke this optimization pass.
+    The wasm-opt bundled with the current wasm-tools workload (v117) predates binaryen PR 7106
+    (bulk-memory-opt / call-indirect-overlong, added in v121) - see dotnet/runtime issue 114723.
+    emcc's own internal link-time wasm-opt pass enables the full modern feature set and produces
+    opcodes (e.g. nontrapping-float-to-int from libwebp) that this second, SDK-driven wasm-opt
+    pass then rejects because its flag set doesn't match. This only matters once wasm-opt itself
+    is new enough to accept the newer enable flags (see the CI publish workflow, which swaps in
+    a newer build); harmless otherwise since Debug builds don't invoke this optimization pass.
   -->
   <ItemGroup Condition="'$(WasmBuildNative)' == 'true'">
     <WasmOptConfigurationFlags Include="--enable-nontrapping-float-to-int" />

--- a/BlazorApp/wwwroot/index.html
+++ b/BlazorApp/wwwroot/index.html
@@ -21,7 +21,7 @@
     </div>
     <script src="_framework/blazor.webassembly.js"></script>
 
-    <script src="/js/canvas.js"></script>
+    <script src="js/canvas.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- Add `.github/workflows/deploy-pages.yml`: publishes `BlazorApp` in Release and deploys to GitHub Pages (enabled at https://shimat.github.io/opencvsharp_blazor_sample/) on every push to `main`, or manually via workflow_dispatch.
- `dotnet publish -c Release` was blocked by two separate wasm-tools workload bugs, reproduced across net8.0 and net10.0 regardless of SDK feature band:
  - **wasm-opt version mismatch** (dotnet/runtime#114723): the bundled `wasm-opt` (v117) predates binaryen PR #7106 (`bulk-memory-opt` / `call-indirect-overlong`, landed by v121). The workflow works around this by downloading and swapping in binaryen `version_130`'s `wasm-opt` before publishing (checksum-verified). Once wasm-opt is new enough, a second, SDK-driven wasm-opt pass also needed its own flag set aligned with what emcc's internal pass already enables — added via a `WasmOptConfigurationFlags` item in `BlazorApp.csproj` (harmless for Debug builds, which don't invoke this pass).
  - **mono-aot-cross crash**: AOT-compiling `OpenCvSharp.dll` crashes the AOT compiler with a native GC assertion (`sgen-alloc.c:409`), on both net8.0 and net10.0. No workaround found yet, so `RunAOTCompilation` now defaults to `false` for Release (was `true`, which made every Release build/publish crash) — pass `-p:RunAOTCompilation=true` to retry once this is fixed upstream.
- Fix `wwwroot/index.html` referencing `/js/canvas.js` as a root-absolute path, which 404s once served from a GitHub Pages project subpath (`/opencvsharp_blazor_sample/...`) instead of the domain root.

## Test plan
- [x] Verified end-to-end on this branch via a temporary push trigger (since removed): `dotnet publish -c Release` succeeds with the wasm-opt swap + flag alignment, and the GitHub Pages upload-artifact step completes — see run https://github.com/shimat/opencvsharp_blazor_sample/actions/runs/29152731162 (the `deploy` job there only failed because of the `github-pages` environment's main-only protection rule, which is expected)
- [ ] Confirm the live deploy job succeeds once this merges to `main` and visit https://shimat.github.io/opencvsharp_blazor_sample/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated deployment of the Blazor app to GitHub Pages.
  * Enabled manual and main-branch deployment options.
  * Added SPA fallback support for reliable navigation on hosted pages.

* **Bug Fixes**
  * Improved compatibility with GitHub Pages subpaths by using relative script loading.
  * Updated release build settings to avoid a WebAssembly compilation issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->