### PR TITLE
Add a "DNN" nav category grouping all five Cv2.Dnn samples

### DIFF
--- a/BlazorApp/Shared/SampleCatalog.cs
+++ b/BlazorApp/Shared/SampleCatalog.cs
@@ -67,13 +67,6 @@ namespace BlazorApp.Shared
                 "Real-time face detection against a live webcam feed using a Haar cascade classifier.",
                 new[] { "Realtime", "Webcam" }),
             new SampleInfo(
-                "samples/dnn-detection",
-                "DNN Face Detection (YuNet)",
-                "Object Detection",
-                "neural-net",
-                "Real-time face detection and landmark localization against a live webcam feed using the YuNet ONNX model via Cv2.Dnn.",
-                new[] { "Realtime", "Webcam" }),
-            new SampleInfo(
                 "samples/aruco",
                 "ArUco Marker Detection",
                 "Object Detection",
@@ -157,6 +150,41 @@ namespace BlazorApp.Shared
                 "panorama",
                 "Stitch two overlapping photos into one panorama.",
                 new[] { "Interactive" }),
+            new SampleInfo(
+                "samples/dnn-detection",
+                "DNN Face Detection (YuNet)",
+                "DNN",
+                "neural-net",
+                "Real-time face detection and landmark localization against a live webcam feed using the YuNet ONNX model via Cv2.Dnn.",
+                new[] { "Realtime", "Webcam" }),
+            new SampleInfo(
+                "samples/super-resolution",
+                "Super Resolution (ESPCN)",
+                "DNN",
+                "upscale",
+                "Upscale a deliberately low-resolution photo 4x with ESPCN, compared against a naive bicubic resize.",
+                new[] { "Static" }),
+            new SampleInfo(
+                "samples/image-classification",
+                "Image Classification (MobileNetV2)",
+                "DNN",
+                "tag",
+                "Classify a photo against ImageNet's 1000 categories using MobileNetV2.",
+                new[] { "Static" }),
+            new SampleInfo(
+                "samples/text-detection",
+                "Text Detection (PP-OCRv3)",
+                "DNN",
+                "text-box",
+                "Detect regions of text in a photo using PP-OCRv3's DB text detector, drawing a polygon around each one.",
+                new[] { "Static" }),
+            new SampleInfo(
+                "samples/object-detection",
+                "Object Detection (YOLOX)",
+                "DNN",
+                "bounding-boxes",
+                "Detect COCO's 80 object categories in a photo using YOLOX, a single-stage anchor-free detector.",
+                new[] { "Static" }),
         };
 
         public static IEnumerable<IGrouping<string, SampleInfo>> ByCategory =>

--- a/BlazorApp/wwwroot/css/app.css
+++ b/BlazorApp/wwwroot/css/app.css
@@ -84,6 +84,10 @@ a, .btn-link {
 .icon-pyramid { background-image: url('../icons/pyramid.svg'); }
 .icon-panorama { background-image: url('../icons/panorama.svg'); }
 .icon-neural-net { background-image: url('../icons/neural-net.svg'); }
+.icon-upscale { background-image: url('../icons/upscale.svg'); }
+.icon-tag { background-image: url('../icons/tag.svg'); }
+.icon-text-box { background-image: url('../icons/text-box.svg'); }
+.icon-bounding-boxes { background-image: url('../icons/bounding-boxes.svg'); }
 
 .sample-category-title {
     margin-top: 2rem;

--- a/BlazorApp/wwwroot/icons/bounding-boxes.svg
+++ b/BlazorApp/wwwroot/icons/bounding-boxes.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect x="1.5" y="2" width="6" height="5" fill="none" stroke="lightgray" stroke-width="1.2"/>
+  <rect x="8.5" y="4" width="6" height="7" fill="none" stroke="lightgray" stroke-width="1.2"/>
+  <rect x="3" y="9.5" width="5" height="4.5" fill="none" stroke="lightgray" stroke-width="1.2"/>
+</svg>

--- a/BlazorApp/wwwroot/icons/tag.svg
+++ b/BlazorApp/wwwroot/icons/tag.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <path d="M2 2 H8 L14 8 L8 14 L2 8 Z" fill="none" stroke="lightgray" stroke-width="1.3"/>
+  <circle cx="5" cy="5" r="1.3" fill="lightgray"/>
+</svg>

--- a/BlazorApp/wwwroot/icons/text-box.svg
+++ b/BlazorApp/wwwroot/icons/text-box.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect x="1.5" y="1.5" width="13" height="13" rx="1" fill="none" stroke="lightgray" stroke-width="1"/>
+  <line x1="4" y1="5.5" x2="12" y2="5.5" stroke="lightgray" stroke-width="1.2"/>
+  <line x1="4" y1="8" x2="12" y2="8" stroke="lightgray" stroke-width="1.2"/>
+  <line x1="4" y1="10.5" x2="9" y2="10.5" stroke="lightgray" stroke-width="1.2"/>
+</svg>

--- a/BlazorApp/wwwroot/icons/upscale.svg
+++ b/BlazorApp/wwwroot/icons/upscale.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect x="1" y="9" width="5" height="5" fill="none" stroke="lightgray" stroke-width="1.2"/>
+  <rect x="7" y="2" width="8" height="8" fill="none" stroke="lightgray" stroke-width="1.4"/>
+  <path d="M6 9 L8.5 6.5" fill="none" stroke="lightgray" stroke-width="1" stroke-dasharray="1.3,1"/>
+</svg>

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Code samples showing [OpenCvSharp](https://github.com/shimat/opencvsharp) runnin
 | `/samples/features` | AKAZE keypoint detection, plus feature matching between an image and a rotated copy of itself |
 | `/samples/template-matching` | Drag out a patch and find every place it matches elsewhere in the photo with `Cv2.MatchTemplate` |
 | `/samples/detection` | Real-time face detection against a live webcam feed using a Haar cascade classifier |
-| `/samples/dnn-detection` | Real-time face detection and landmark localization against a live webcam feed using the YuNet ONNX model via `Cv2.Dnn` |
 | `/samples/aruco` | Generates an ArUco marker and composites it onto a photo at a random position/rotation, then detects it |
 | `/samples/color-tracking` | Tunes an HSV range live and tracks the largest matching blob in the webcam feed with `Cv2.InRange` + `FindContours` |
 | `/samples/optical-flow` | Tracks corner points frame-to-frame in the webcam feed with `Cv2.CalcOpticalFlowPyrLK` |
@@ -30,6 +29,11 @@ Code samples showing [OpenCvSharp](https://github.com/shimat/opencvsharp) runnin
 | `/samples/photo-editing` | Drag-to-place `Cv2.SeamlessClone` blending compared against a naive paste, plus paint-to-remove `Cv2.Inpaint` |
 | `/samples/pyramid-blend` | Blends two photos across a seam using Laplacian pyramids instead of a hard cut |
 | `/samples/stitching` | Stitches two overlapping photos into one panorama with `Cv2.Stitcher`; stitching is a known-issue preview (see below) |
+| `/samples/dnn-detection` | Real-time face detection and landmark localization against a live webcam feed using the YuNet ONNX model via `Cv2.Dnn` |
+| `/samples/super-resolution` | Upscales a deliberately low-resolution photo 4x with ESPCN via `Cv2.DnnSuperres`, compared against a naive bicubic resize |
+| `/samples/image-classification` | Classifies a photo against ImageNet's 1000 categories using MobileNetV2 via `Cv2.Dnn.ClassificationModel` |
+| `/samples/text-detection` | Detects regions of text in a photo using PP-OCRv3's DB detector via `Cv2.Dnn.TextDetectionModelDB` |
+| `/samples/object-detection` | Detects COCO's 80 object categories in a photo using YOLOX via a raw `Cv2.Dnn.Net` and a hand-written grid/stride decode |
 
 Most photo-based samples default to a bundled test image, but accept any uploaded photo via a file picker (normalized to a fixed size, with a button to reset back to the default) - the synthetic-image samples (Document Scanner, Watershed & Hough's Hough half, ArUco) don't offer this since they need their specific generated content to demonstrate the algorithm.
 


### PR DESCRIPTION
## Summary
- Stacked on #19 (Object Detection / YOLOX). Final step of the DNN samples series.
- Adds a new "DNN" nav category and moves `DNN Face Detection (YuNet)` into it from `Object Detection`, alongside the four samples just added (Super Resolution, Image Classification, Text Detection, Object Detection) - so every `Cv2.Dnn`-based sample lives in one place instead of being scattered across task-based categories.
- Adds a distinct icon per new sample (`upscale`, `tag`, `text-box`, `bounding-boxes`) instead of reusing one glyph for all four.
- Updates the top-level README's page table to match.

## Test plan
- [x] `dotnet build -c Debug` succeeds with no warnings
- [x] Verified in-browser: nav menu shows a "DNN" category with all 5 samples, each navigates correctly; landing page's card gallery shows the same 5 cards with their new icons loading (200, not 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)