### PR TITLE
Add .coderabbit.yaml so CodeRabbit reviews stacked PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+
+reviews:
+  profile: "chill"
+  poem: false
+  review_status: false
+  review_details: false
+  suggested_reviewers: false
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - ".*"


### PR DESCRIPTION
## Summary
- CodeRabbit's auto-review only triggers by default when a PR's base branch is the repo's default branch. Every PR in a stacked chain (base != `main`) was silently skipped - confirmed on #17-#20, each showing "Auto reviews are disabled on base/target branches other than the default branch."
- Adds `.coderabbit.yaml` with `reviews.auto_review.base_branches: ['.*']` to opt every base branch in.
- Other settings (`profile: chill`, `poem: false`, etc.) mirror [shimat/opencvsharp](https://github.com/shimat/opencvsharp)'s own `.coderabbit.yaml` for consistency across repos.

## Test plan
- [ ] After merging, open/update a stacked PR and confirm CodeRabbit posts a review instead of the "Auto reviews are disabled" notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configuration for automated code reviews.
  * Set English as the review language and enabled a relaxed review style.
  * Disabled drafts and selected review detail sections for automated reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->