### PR TITLE
Add Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "matchManagers": ["nuget"],
+      "matchPackageNames": ["/^OpenCvSharp5/"],
+      "groupName": "OpenCvSharp5",
+      "groupSlug": "opencvsharp5"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `renovate.json` to catch up promptly when OpenCvSharp5 NuGet packages are updated, grouping the `OpenCvSharp5.*` packages into a single PR since they need to stay on matching versions
- Same config as [shimat/opencvsharp_samples#59](https://github.com/shimat/opencvsharp_samples/pull/59)

## Test plan
- [ ] Enable the Renovate GitHub App on this repository (manual step, not part of this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)