### PR TITLE
Add a build/test CI check; bump Actions to latest majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-dotnet@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '10.0.3xx'
+
+      - name: Install wasm-tools workload
+        run: dotnet workload install wasm-tools
+
+      - name: Restore
+        run: dotnet restore
+
+      # Debug, not Release: Release triggers the wasm-opt version mismatch worked around in
+      # deploy-pages.yml (dotnet/runtime#114723). This job only needs to catch build breakage
+      # from dependency updates (e.g. Renovate), so Debug is enough and skips that workaround.
+      - name: Build
+        run: dotnet build --no-restore -c Debug
+
+      - name: Test
+        run: dotnet test BlazorApp.Tests/BlazorApp.Tests.csproj --no-build -c Debug

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -23,9 +23,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.3xx'
 
@@ -54,7 +54,7 @@ jobs:
           touch publish-output/wwwroot/.nojekyll
           cp publish-output/wwwroot/index.html publish-output/wwwroot/404.html
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: publish-output/wwwroot
 
@@ -69,4 +69,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/BlazorApp.Tests/BlazorApp.Tests.csproj
+++ b/BlazorApp.Tests/BlazorApp.Tests.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BlazorApp\BlazorApp.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/BlazorApp.Tests/SampleCatalogTests.cs
+++ b/BlazorApp.Tests/SampleCatalogTests.cs
@@ -1,0 +1,60 @@
+using System.Reflection;
+using BlazorApp.Shared;
+using Microsoft.AspNetCore.Components;
+
+namespace BlazorApp.Tests;
+
+public class SampleCatalogTests
+{
+    // Every @page directive compiles into a RouteAttribute on the generated component class, so
+    // reflecting over the built assembly catches a SampleCatalog entry pointing at a route no
+    // page actually serves, without hard-coding a path to the Pages folder's source files.
+    private static readonly HashSet<string> RoutedPages = typeof(SampleCatalog).Assembly
+        .GetTypes()
+        .SelectMany(t => t.GetCustomAttributes<RouteAttribute>())
+        .Select(a => a.Template.TrimStart('/'))
+        .ToHashSet();
+
+    public static TheoryData<SampleInfo> Samples() => new(SampleCatalog.Samples);
+
+    [Fact]
+    public void Routes_are_unique()
+    {
+        var duplicates = SampleCatalog.Samples
+            .GroupBy(s => s.Route)
+            .Where(g => g.Count() > 1)
+            .Select(g => g.Key);
+
+        Assert.Empty(duplicates);
+    }
+
+    [Fact]
+    public void Every_sample_route_has_a_matching_page()
+    {
+        var missing = SampleCatalog.Samples
+            .Select(s => s.Route)
+            .Where(route => !RoutedPages.Contains(route));
+
+        Assert.Empty(missing);
+    }
+
+    [Theory]
+    [MemberData(nameof(Samples))]
+    public void Sample_metadata_fields_are_populated(SampleInfo sample)
+    {
+        Assert.False(string.IsNullOrWhiteSpace(sample.Route));
+        Assert.False(string.IsNullOrWhiteSpace(sample.Title));
+        Assert.False(string.IsNullOrWhiteSpace(sample.Category));
+        Assert.False(string.IsNullOrWhiteSpace(sample.Icon));
+        Assert.False(string.IsNullOrWhiteSpace(sample.Description));
+        Assert.NotEmpty(sample.Tags);
+    }
+
+    [Fact]
+    public void ByCategory_accounts_for_every_sample_exactly_once()
+    {
+        var total = SampleCatalog.ByCategory.Sum(g => g.Count());
+
+        Assert.Equal(SampleCatalog.Samples.Count, total);
+    }
+}

--- a/BlazorApp.Tests/xunit.runner.json
+++ b/BlazorApp.Tests/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json"
+}

--- a/OpenCvSharpBlazorSamples.sln
+++ b/OpenCvSharpBlazorSamples.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.0.31919.166
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlazorApp", "BlazorApp\BlazorApp.csproj", "{AB0B9C16-C0A8-403C-A30D-50A7074D5935}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorApp.Tests", "BlazorApp.Tests\BlazorApp.Tests.csproj", "{E395C394-D4F0-4596-A01A-41FD7AD47791}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +41,26 @@ Global
 		{AB0B9C16-C0A8-403C-A30D-50A7074D5935}.Release|x64.Build.0 = Release|Any CPU
 		{AB0B9C16-C0A8-403C-A30D-50A7074D5935}.Release|x86.ActiveCfg = Release|Any CPU
 		{AB0B9C16-C0A8-403C-A30D-50A7074D5935}.Release|x86.Build.0 = Release|Any CPU
+		{E395C394-D4F0-4596-A01A-41FD7AD47791}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E395C394-D4F0-4596-A01A-41FD7AD47791}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E395C394-D4F0-4596-A01A-41FD7AD47791}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{E395C394-D4F0-4596-A01A-41FD7AD47791}.Debug|ARM.Build.0 = Debug|Any CPU
+		{E395C394-D4F0-4596-A01A-41FD7AD47791}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{E395C394-D4F0-4596-A01A-41FD7AD47791}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{E395C394-D4F0-4596-A01A-41FD7AD47791}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E395C394-D4F0-4596-A01A-41FD7AD47791}.Debug|x64.Build.0 = Debug|Any CPU
+		{E395C394-D4F0-4596-A01A-41FD7AD47791}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E395C394-D4F0-4596-A01A-41FD7AD47791}.Debug|x86.Build.0 = Debug|Any CPU
+		{E395C394-D4F0-4596-A01A-41FD7AD47791}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E395C394-D4F0-4596-A01A-41FD7AD47791}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E395C394-D4F0-4596-A01A-41FD7AD47791}.Release|ARM.ActiveCfg = Release|Any CPU
+		{E395C394-D4F0-4596-A01A-41FD7AD47791}.Release|ARM.Build.0 = Release|Any CPU
+		{E395C394-D4F0-4596-A01A-41FD7AD47791}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{E395C394-D4F0-4596-A01A-41FD7AD47791}.Release|ARM64.Build.0 = Release|Any CPU
+		{E395C394-D4F0-4596-A01A-41FD7AD47791}.Release|x64.ActiveCfg = Release|Any CPU
+		{E395C394-D4F0-4596-A01A-41FD7AD47791}.Release|x64.Build.0 = Release|Any CPU
+		{E395C394-D4F0-4596-A01A-41FD7AD47791}.Release|x86.ActiveCfg = Release|Any CPU
+		{E395C394-D4F0-4596-A01A-41FD7AD47791}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml`: on push/PR to `main`, restores, builds (Debug), and runs tests — a fast signal for whether a Renovate dependency bump still builds, without needing the Release-only wasm-opt workaround already in `deploy-pages.yml`.
- Add `BlazorApp.Tests`, an xUnit v3 (`xunit.v3.mtp-v2`) project referencing `BlazorApp` and covering `SampleCatalog`'s invariants: unique routes, every route resolves to an actual `@page` route (checked via reflection over the built assembly's `RouteAttribute`s), required metadata fields are populated, and `ByCategory` accounts for every sample exactly once.
- Add `global.json` opting into the `Microsoft.Testing.Platform` `dotnet test` runner, required for `xunit.v3.mtp-v2` on the .NET 10 SDK.
- Bump `actions/checkout` v4→v7, `actions/setup-dotnet` v4→v6, `actions/upload-pages-artifact` v3→v5, `actions/deploy-pages` v4→v5 in both workflows.

## Test plan
- [x] `dotnet restore` / `dotnet build -c Debug` / `dotnet test BlazorApp.Tests` all pass locally from a clean checkout (27/27 tests).
- [ ] CI run on this PR is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated checks to verify sample routes, metadata, and category coverage.
  * Added a dedicated test project targeting .NET 10.

* **CI/CD**
  * Added continuous build and test validation for pull requests and pushes to the main branch.
  * Updated GitHub Pages deployment actions to newer versions.

* **Bug Fixes**
  * Improved detection of missing, duplicate, or mismatched sample routes and metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->